### PR TITLE
Set errno when simulating failed allocation

### DIFF
--- a/nallocfuzz.c
+++ b/nallocfuzz.c
@@ -235,6 +235,7 @@ static bool fuzz_nalloc_fail(size_t size, const char *op) {
 
 void *calloc(size_t nmemb, size_t size) {
     if (fuzz_nalloc_fail(size, "calloc")) {
+        errno = ENOMEM;
         return NULL;
     }
     return __interceptor_calloc(nmemb, size);
@@ -242,6 +243,7 @@ void *calloc(size_t nmemb, size_t size) {
 
 void *malloc(size_t size) {
     if (fuzz_nalloc_fail(size, "malloc")) {
+        errno = ENOMEM;
         return NULL;
     }
     return __interceptor_malloc(size);
@@ -249,6 +251,7 @@ void *malloc(size_t size) {
 
 void *realloc(void *ptr, size_t size) {
     if (fuzz_nalloc_fail(size, "realloc")) {
+        errno = ENOMEM;
         return NULL;
     }
     return __interceptor_realloc(ptr, size);


### PR DESCRIPTION
From malloc(2):
    SUSv2 requires malloc(), calloc(), and realloc() to set errno to
    ENOMEM upon failure.  Glibc assumes that this is done (and the glibc
    versions of these routines do this); if you use a private malloc
    implementation that does not set errno, then certain library routines
    may fail without having a reason in errno.

See: https://github.com/google/oss-fuzz/pull/9902#issuecomment-1556038788